### PR TITLE
fix: clip filter output to filter region to prevent feFlood bleeding (#130)

### DIFF
--- a/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
+++ b/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
@@ -552,6 +552,80 @@ public final class Defs {
         return last;
     }
 
+    /**
+     * Compute the filter region from the sourceGraphic's non-transparent bounds,
+     * extended by 10% on each side (SVG default filter region). If the filter node
+     * has explicit x/y/width/height attributes, those override the default. Returns
+     * a Rectangle, or null if the image is fully transparent.
+     */
+    public static java.awt.Rectangle computeFilterRegion(BufferedImage sourceGraphic, Node filterNode) {
+        int w = sourceGraphic.getWidth();
+        int h = sourceGraphic.getHeight();
+        int[] pixels = ((DataBufferInt) sourceGraphic.getRaster().getDataBuffer()).getData();
+        int minX = w, minY = h, maxX = -1, maxY = -1;
+        for (int y = 0; y < h; y++) {
+            int off = y * w;
+            for (int x = 0; x < w; x++) {
+                if ((pixels[off + x] >>> 24) != 0) {
+                    if (x < minX)
+                        minX = x;
+                    if (x > maxX)
+                        maxX = x;
+                    if (y < minY)
+                        minY = y;
+                    if (y > maxY)
+                        maxY = y;
+                }
+            }
+        }
+        if (maxX < minX) {
+            return null;
+        }
+        int bw = maxX - minX + 1;
+        int bh = maxY - minY + 1;
+
+        // Check for explicit filter region attributes on the <filter> element
+        if (filterNode != null && filterNode.has("width") && filterNode.has("height")) {
+            boolean userSpace = "userSpaceOnUse".equals(filterNode.get("filterUnits"));
+            if (userSpace) {
+                int fx = (int) parseDoubleOr(filterNode.get("x"), 0);
+                int fy = (int) parseDoubleOr(filterNode.get("y"), 0);
+                int fw = (int) parseDoubleOr(filterNode.get("width"), w);
+                int fh = (int) parseDoubleOr(filterNode.get("height"), h);
+                return new java.awt.Rectangle(fx, fy, fw, fh);
+            }
+            double pctX = parsePercentOrFraction(filterNode.get("x", "-10%"), -0.1);
+            double pctY = parsePercentOrFraction(filterNode.get("y", "-10%"), -0.1);
+            double pctW = parsePercentOrFraction(filterNode.get("width", "120%"), 1.2);
+            double pctH = parsePercentOrFraction(filterNode.get("height", "120%"), 1.2);
+            int fx = Math.max(0, (int) (minX + pctX * bw));
+            int fy = Math.max(0, (int) (minY + pctY * bh));
+            int fw = Math.min(w - fx, (int) (pctW * bw));
+            int fh = Math.min(h - fy, (int) (pctH * bh));
+            return new java.awt.Rectangle(fx, fy, fw, fh);
+        }
+
+        // Default: bbox + 10% padding
+        int padX = Math.max(1, (int) Math.ceil(bw * 0.1));
+        int padY = Math.max(1, (int) Math.ceil(bh * 0.1));
+        return new java.awt.Rectangle(Math.max(0, minX - padX), Math.max(0, minY - padY), Math.min(w, bw + 2 * padX),
+                Math.min(h, bh + 2 * padY));
+    }
+
+    private static double parsePercentOrFraction(String value, double defaultVal) {
+        if (value == null || value.isEmpty()) {
+            return defaultVal;
+        }
+        try {
+            if (value.endsWith("%")) {
+                return Double.parseDouble(value.substring(0, value.length() - 1)) / 100.0;
+            }
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return defaultVal;
+        }
+    }
+
     private static BufferedImage pickBuffer(BufferedImage avoid1, BufferedImage avoid2, BufferedImage buf1,
             BufferedImage buf2, BufferedImage buf3) {
         if (buf1 != avoid1 && buf1 != avoid2) {

--- a/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
+++ b/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
@@ -430,7 +430,12 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
 
         if (effectContext != null) {
             BufferedImage renderedImage = effectSourceImage;
+            java.awt.Rectangle filterClip = null;
             if (filterName != null) {
+                // Compute the filter region BEFORE filtering so that primitives like
+                // feFlood don't bleed into other elements' areas when composited back.
+                Node filterNode = this.filters.get(filterName);
+                filterClip = Defs.computeFilterRegion(effectSourceImage, filterNode);
                 renderedImage = Defs.applyFilter(this, filterName, renderedImage);
             }
             if (maskName != null) {
@@ -440,7 +445,14 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
             if (groupOpacity) {
                 effectBaseContext.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) opacity));
             }
-            effectBaseContext.drawImage(renderedImage, 0, 0, null);
+            if (filterClip != null) {
+                Shape prevClip = effectBaseContext.getClip();
+                effectBaseContext.clip(filterClip);
+                effectBaseContext.drawImage(renderedImage, 0, 0, null);
+                effectBaseContext.setClip(prevClip);
+            } else {
+                effectBaseContext.drawImage(renderedImage, 0, 0, null);
+            }
             if (groupOpacity) {
                 effectBaseContext.setComposite(savedComposite);
             }

--- a/src/test/java/io/brunoborges/jairosvg/ShapeRenderingTest.java
+++ b/src/test/java/io/brunoborges/jairosvg/ShapeRenderingTest.java
@@ -407,7 +407,7 @@ class ShapeRenderingTest {
         String filteredSvg = """
                 <svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
                   <defs>
-                    <filter id="tile">
+                    <filter id="tile" filterUnits="userSpaceOnUse" x="0" y="0" width="120" height="60">
                       <feTile/>
                     </filter>
                   </defs>


### PR DESCRIPTION
## Problem

Filter primitives like `feFlood` fill the entire `sourceGraphic` canvas. When multiple filtered elements exist in the same SVG, each subsequent filter's output overwrites all previous elements via `drawImage(renderedImage, 0, 0)`, producing identical visual output for all blend modes.

## Root Cause

`applyFilter()` operates on a full-canvas `BufferedImage`. Primitives like `feFlood` fill every pixel. The compositing step in `Surface.draw()` blits the entire canvas back — overwriting everything rendered so far.

## Fix

Clip the `drawImage` compositing step in `Surface.draw()` to the SVG filter region before compositing the filter result. The filter region is computed from the source element's bounding box + 10% padding (per SVG 1.1 default), or from explicit `<filter>` element attributes (`x`, `y`, `width`, `height`) when present.

Supports both `filterUnits="objectBoundingBox"` (percentage/fraction values) and `filterUnits="userSpaceOnUse"` (absolute coordinates).

## Changes

- **Defs.java**: Updated `computeFilterRegion()` to accept a `Node filterNode` parameter and parse explicit filter region attributes
- **Surface.java**: Added clip-to-filter-region before `drawImage` in the filter compositing block
- **ShapeRenderingTest.java**: Updated tile filter test to use `filterUnits="userSpaceOnUse"` with explicit dimensions

All 23 visual comparison test cases pass. All unit tests pass.

Fixes #130