### PR TITLE
Bounds-aware sub-region effect buffers for masks and opacity

### DIFF
--- a/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
+++ b/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
@@ -801,7 +801,8 @@ public final class Defs {
     }
 
     /** Render and apply luminance mask to an off-screen source image. */
-    public static BufferedImage paintMask(Surface surface, Node node, String name, BufferedImage sourceImage) {
+    public static BufferedImage paintMask(Surface surface, Node node, String name, BufferedImage sourceImage,
+            java.awt.geom.AffineTransform subRegionTransform) {
         Node maskNode = surface.masks.get(name);
         if (maskNode == null) {
             return sourceImage;
@@ -820,6 +821,9 @@ public final class Defs {
         }
         Graphics2D maskG2d = maskImage.createGraphics();
         maskG2d.setRenderingHints(surface.context.getRenderingHints());
+        if (subRegionTransform != null) {
+            maskG2d.setTransform(subRegionTransform);
+        }
 
         Graphics2D savedContext = surface.context;
         GeneralPath savedPath = surface.path;

--- a/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
+++ b/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import io.brunoborges.jairosvg.css.Colors;
+import io.brunoborges.jairosvg.dom.BoundingBox;
 import io.brunoborges.jairosvg.dom.Node;
 import io.brunoborges.jairosvg.dom.SvgFont;
 import io.brunoborges.jairosvg.draw.Defs;
@@ -299,18 +300,68 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
         Graphics2D effectContext = null;
         BufferedImage effectSourceImage = null;
         boolean ownEffectBuffer = false;
+        boolean subRegionEffect = false;
+        int ebX = 0, ebY = 0;
+        AffineTransform subRegionXform = null;
         if (filterName != null || maskName != null || groupOpacity) {
             effectBaseContext = context;
-            int iw = image.getWidth();
-            int ih = image.getHeight();
-            if (!effectBufferInUse && effectBuffer != null && effectBuffer.getWidth() == iw
+            int fullW = image.getWidth();
+            int fullH = image.getHeight();
+            int iw = fullW, ih = fullH;
+
+            // Sub-region effect buffers for mask/opacity-only elements (no filter).
+            // Filters are excluded because primitives like feFlood fill the entire
+            // buffer, making the result dependent on buffer dimensions. Filter
+            // sub-region optimization is handled inside applyFilter() instead.
+            if (filterName == null) {
+                BoundingBox.Box bbox = BoundingBox.calculate(this, node);
+                if (bbox != null && BoundingBox.isNonEmpty(bbox)) {
+                    // For masks, extend the region to include mask children content.
+                    // Mask shapes clipped by the buffer boundary produce different
+                    // anti-aliasing than when fully contained.
+                    if (maskName != null) {
+                        Node maskNode = this.masks.get(maskName);
+                        if (maskNode != null) {
+                            BoundingBox.Box maskBbox = BoundingBox.group(this, maskNode);
+                            if (maskBbox != null && BoundingBox.isValid(maskBbox)) {
+                                bbox = BoundingBox.combine(bbox, maskBbox);
+                            }
+                        }
+                    }
+
+                    AffineTransform xf = context.getTransform();
+                    double[] pts = {bbox.minX(), bbox.minY(), bbox.minX() + bbox.width(), bbox.minY(), bbox.minX(),
+                            bbox.minY() + bbox.height(), bbox.minX() + bbox.width(), bbox.minY() + bbox.height()};
+                    double[] dst = new double[8];
+                    xf.transform(pts, 0, dst, 0, 4);
+
+                    double dMinX = Math.min(Math.min(dst[0], dst[2]), Math.min(dst[4], dst[6]));
+                    double dMinY = Math.min(Math.min(dst[1], dst[3]), Math.min(dst[5], dst[7]));
+                    double dMaxX = Math.max(Math.max(dst[0], dst[2]), Math.max(dst[4], dst[6]));
+                    double dMaxY = Math.max(Math.max(dst[1], dst[3]), Math.max(dst[5], dst[7]));
+
+                    int pad = computeEffectPadding(node, null);
+                    ebX = Math.max(0, (int) Math.floor(dMinX) - pad);
+                    ebY = Math.max(0, (int) Math.floor(dMinY) - pad);
+                    int ebW = Math.min(fullW, (int) Math.ceil(dMaxX) + pad) - ebX;
+                    int ebH = Math.min(fullH, (int) Math.ceil(dMaxY) + pad) - ebY;
+
+                    if (ebW > 0 && ebH > 0 && (long) ebW * ebH < (long) fullW * fullH * 4 / 5) {
+                        iw = ebW;
+                        ih = ebH;
+                        subRegionEffect = true;
+                    }
+                }
+            }
+
+            if (!subRegionEffect && !effectBufferInUse && effectBuffer != null && effectBuffer.getWidth() == iw
                     && effectBuffer.getHeight() == ih) {
                 effectSourceImage = effectBuffer;
                 java.util.Arrays.fill(
                         ((java.awt.image.DataBufferInt) effectSourceImage.getRaster().getDataBuffer()).getData(), 0);
             } else {
                 effectSourceImage = new BufferedImage(iw, ih, BufferedImage.TYPE_INT_ARGB);
-                if (!effectBufferInUse) {
+                if (!effectBufferInUse && !subRegionEffect) {
                     effectBuffer = effectSourceImage;
                 }
             }
@@ -318,7 +369,13 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
             ownEffectBuffer = true;
             effectContext = effectSourceImage.createGraphics();
             effectContext.setRenderingHints(effectBaseContext.getRenderingHints());
-            effectContext.setTransform(effectBaseContext.getTransform());
+            if (subRegionEffect) {
+                subRegionXform = new AffineTransform(effectBaseContext.getTransform());
+                subRegionXform.preConcatenate(AffineTransform.getTranslateInstance(-ebX, -ebY));
+                effectContext.setTransform(subRegionXform);
+            } else {
+                effectContext.setTransform(effectBaseContext.getTransform());
+            }
             effectContext.setClip(effectBaseContext.getClip());
             effectContext.setComposite(effectBaseContext.getComposite());
             effectContext.setStroke(effectBaseContext.getStroke());
@@ -469,19 +526,28 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
                 renderedImage = Defs.applyFilter(this, filterName, renderedImage);
             }
             if (maskName != null) {
-                renderedImage = Defs.paintMask(this, node, maskName, renderedImage);
+                renderedImage = Defs.paintMask(this, node, maskName, renderedImage,
+                        subRegionEffect ? subRegionXform : null);
             }
             context = effectBaseContext;
             if (groupOpacity) {
                 effectBaseContext.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) opacity));
             }
-            if (filterClip != null) {
-                Shape prevClip = effectBaseContext.getClip();
-                effectBaseContext.clip(filterClip);
-                effectBaseContext.drawImage(renderedImage, 0, 0, null);
-                effectBaseContext.setClip(prevClip);
+            if (subRegionEffect) {
+                // Composite sub-region at device coordinates using identity transform
+                AffineTransform baseXform = effectBaseContext.getTransform();
+                effectBaseContext.setTransform(new AffineTransform());
+                effectBaseContext.drawImage(renderedImage, ebX, ebY, null);
+                effectBaseContext.setTransform(baseXform);
             } else {
-                effectBaseContext.drawImage(renderedImage, 0, 0, null);
+                if (filterClip != null) {
+                    Shape prevClip = effectBaseContext.getClip();
+                    effectBaseContext.clip(filterClip);
+                    effectBaseContext.drawImage(renderedImage, 0, 0, null);
+                    effectBaseContext.setClip(prevClip);
+                } else {
+                    effectBaseContext.drawImage(renderedImage, 0, 0, null);
+                }
             }
             if (groupOpacity) {
                 effectBaseContext.setComposite(savedComposite);
@@ -500,6 +566,55 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
 
     private void configureStroke(Node node) {
         // These are set during draw for each node's stroke
+    }
+
+    /**
+     * Compute device-pixel padding for the sub-region effect buffer. Accounts for
+     * stroke width and filter blur/offset extent.
+     */
+    private int computeEffectPadding(Node node, String filterName) {
+        int pad = 4; // base padding for anti-aliasing and rounding
+
+        // Stroke extent
+        String stroke = node.get("stroke", "none");
+        if (!"none".equals(stroke)) {
+            double sw = size(this, node.get("stroke-width", "1"));
+            AffineTransform xf = context.getTransform();
+            double sx = Math.sqrt(xf.getScaleX() * xf.getScaleX() + xf.getShearX() * xf.getShearX());
+            double sy = Math.sqrt(xf.getScaleY() * xf.getScaleY() + xf.getShearY() * xf.getShearY());
+            pad += (int) Math.ceil(sw * Math.max(sx, sy) / 2) + 1;
+        }
+
+        // Filter blur/offset extent (in device pixels)
+        if (filterName != null) {
+            Node filterNode = this.filters.get(filterName);
+            if (filterNode != null) {
+                int blurPad = 0, offsetPad = 0;
+                for (Node child : filterNode.children) {
+                    switch (child.tag) {
+                        case "feGaussianBlur" -> {
+                            double sigma = parseDoubleOr(child.get("stdDeviation"), 0);
+                            blurPad = Math.max(blurPad, (int) Math.ceil(sigma * 3));
+                        }
+                        case "feDropShadow" -> {
+                            double sigma = parseDoubleOr(child.get("stdDeviation"), 0);
+                            blurPad = Math.max(blurPad, (int) Math.ceil(sigma * 3));
+                            offsetPad = Math.max(offsetPad, (int) Math.ceil(Math.abs(parseDoubleOr(child.get("dx"), 0)))
+                                    + (int) Math.ceil(Math.abs(parseDoubleOr(child.get("dy"), 0))));
+                        }
+                        case "feOffset" -> {
+                            offsetPad = Math.max(offsetPad, (int) Math.ceil(Math.abs(parseDoubleOr(child.get("dx"), 0)))
+                                    + (int) Math.ceil(Math.abs(parseDoubleOr(child.get("dy"), 0))));
+                        }
+                        default -> {
+                        }
+                    }
+                }
+                pad += blurPad + offsetPad;
+            }
+        }
+
+        return pad;
     }
 
     private void applyClip(Node node) {


### PR DESCRIPTION
## Summary

Implements Phase 2 from issue #153: geometric bounding box computation for sub-region effect buffer allocation in `Surface.draw()`.

### What changed

For elements with **mask** or **group opacity** (but not filters), the effect buffer is now allocated at the element's bounding box size instead of full canvas dimensions. This reduces memory allocation and pixel processing for the mask luminance loop and opacity compositing.

### How it works

1. **BoundingBox.calculate()** computes the element's geometric bounds in user space
2. All 4 corners are transformed to device space via the current `AffineTransform` (handles rotation/skew)
3. For masked elements, the bbox is extended to include mask children bounds (via `BoundingBox.combine`) — this prevents anti-aliasing artifacts from shapes clipped at buffer boundaries
4. Padding is added for stroke width and anti-aliasing
5. If the sub-region is <80% of canvas area, a smaller buffer is allocated
6. The `effectContext` transform is adjusted with `translate(-bboxX, -bboxY)` so rendering maps correctly to the smaller buffer
7. Compositing uses identity transform at device pixel coordinates

### Why filters are excluded

Filter primitives like `feFlood` fill the **entire** buffer with solid color — making the rendered result dependent on buffer dimensions. Sub-region filter optimization is already handled inside `applyFilter()` (PR #152), which extracts and processes a sub-region from the full-canvas buffer.

### Anti-aliasing discovery

Java2D's anti-aliasing produces different results when shapes extend beyond the buffer boundary (even with integer translates). A circle partially outside the buffer gets different edge pixel values than the same circle fully contained. This was verified empirically and is why the sub-region must encompass both the element AND mask content bounds.

### Correctness

- All 79 unit tests pass
- All 23 comparison SVGs are **pixel-identical** to reference PNGs
- No benchmark regressions across all 23 test cases

### Performance impact

The benchmark's mask SVG (`15_masks.svg`) uses full-canvas background rects in all three masks, so the union bbox covers the entire canvas and the optimization doesn't activate. The optimization benefits real-world SVGs with:
- **Localized masks** (mask content confined to the element area)
- **Opacity groups** (`<g opacity="...">`) with small children on large canvases

For a small masked element on an 800×600 canvas (e.g., 100×100 element with localized mask), the effect buffer shrinks from 480,000 to ~14,400 pixels (97% reduction), directly reducing the mask luminance loop from O(480K) to O(14K).

Closes #153