### PR TITLE
perf: avoid caching sub-region maskBuffer in paintMask()

### DIFF
--- a/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
+++ b/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
@@ -805,13 +805,17 @@ public final class Defs {
         int w = sourceImage.getWidth();
         int h = sourceImage.getHeight();
 
-        // TYPE_INT_ARGB mask buffer — reuse or allocate
+        // TYPE_INT_ARGB mask buffer — reuse full-canvas buffer; sub-region buffers are
+        // temporary and not cached to avoid evicting the reusable full-canvas instance.
+        boolean isSubRegion = subRegionTransform != null;
         BufferedImage maskImage = surface.maskBuffer;
-        if (maskImage == null || maskImage.getWidth() != w || maskImage.getHeight() != h) {
-            maskImage = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-            surface.maskBuffer = maskImage;
-        } else {
+        if (!isSubRegion && maskImage != null && maskImage.getWidth() == w && maskImage.getHeight() == h) {
             java.util.Arrays.fill(((DataBufferInt) maskImage.getRaster().getDataBuffer()).getData(), 0);
+        } else {
+            maskImage = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+            if (!isSubRegion) {
+                surface.maskBuffer = maskImage;
+            }
         }
         Graphics2D maskG2d = maskImage.createGraphics();
         maskG2d.setRenderingHints(surface.context.getRenderingHints());

--- a/src/test/java/io/brunoborges/jairosvg/ShapeRenderingTest.java
+++ b/src/test/java/io/brunoborges/jairosvg/ShapeRenderingTest.java
@@ -605,6 +605,43 @@ class ShapeRenderingTest {
     }
 
     @Test
+    void testSubRegionMaskCorrectness() throws Exception {
+        // Small masked element (50x30) on a large canvas (500x400).
+        // Sub-region optimization should allocate a ~50x30 effect buffer instead of
+        // 500x400. Validates that: pixels inside the element have correct luminance-derived
+        // alpha, pixels outside the element are fully transparent, and the surrounding
+        // canvas area is not corrupted.
+        String svg = """
+                <svg xmlns="http://www.w3.org/2000/svg" width="500" height="400">
+                  <defs>
+                    <mask id="halfMask">
+                      <rect width="500" height="400" fill="white"/>
+                    </mask>
+                  </defs>
+                  <rect x="200" y="150" width="50" height="30" fill="blue" mask="url(#halfMask)"/>
+                </svg>
+                """;
+
+        BufferedImage image = ImageIO
+                .read(new ByteArrayInputStream(JairoSVG.svg2png(svg.getBytes(StandardCharsets.UTF_8))));
+
+        // Pixel inside masked element: white mask → full luminance → alpha should be 255
+        int insideRGB = image.getRGB(220, 162);
+        int insideAlpha = (insideRGB >>> 24) & 0xFF;
+        int insideBlue = insideRGB & 0xFF;
+        assertEquals(255, insideAlpha, "Pixel inside masked element should be fully opaque (white mask)");
+        assertTrue(insideBlue > 200, "Pixel inside masked element should show the blue fill");
+
+        // Pixel outside masked element: no element rendered → should be transparent
+        int outsideAlpha = (image.getRGB(10, 10) >>> 24) & 0xFF;
+        assertEquals(0, outsideAlpha, "Pixel outside masked element region should be transparent");
+
+        // Pixel adjacent to but outside the element bbox: also transparent
+        int adjacentAlpha = (image.getRGB(260, 162) >>> 24) & 0xFF;
+        assertEquals(0, adjacentAlpha, "Pixel just outside element bbox should be transparent");
+    }
+
+    @Test
     void testMaskLuminanceCombinesMaskColorAndAlpha() throws Exception {
         String svg = """
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">


### PR DESCRIPTION
Closes #154

## Summary

The core sub-region optimization for masks was already implemented on `main` (via `6a2a73a` + `3ad2520`): when a masked element's bounding box is small relative to the canvas, `Surface.draw()` allocates a small `effectSourceImage` and `paintMask()` operates on it — reducing the luminance loop from `canvasW × canvasH` to `bboxW × bboxH` pixels.

This PR addresses the remaining gap: **`maskBuffer` caching policy**.

## Problem

When `paintMask()` runs with a sub-region buffer (`subRegionTransform != null`), it saved the small sub-region buffer to `surface.maskBuffer`. This evicts the reusable full-canvas buffer, so the next full-canvas mask call must re-allocate a large buffer. If masks alternate between sub-region and full-canvas sizes, this causes repeated allocation/GC pressure.

## Fix

Mirror the pattern already used for `effectBuffer` in `Surface.draw()`:
- **Full-canvas masks** (`subRegionTransform == null`): reuse `surface.maskBuffer` if size matches, otherwise allocate and cache
- **Sub-region masks** (`subRegionTransform != null`): allocate a temporary buffer without saving to `surface.maskBuffer`

This keeps `maskBuffer` at full-canvas size when needed, while sub-region buffers remain small short-lived objects handled by GC.

## Test

Added `testSubRegionMaskCorrectness()` to `ShapeRenderingTest` — renders a small masked element (50×30) on a large canvas (500×400) and verifies:
- Pixels inside the masked element are fully opaque with the correct fill color
- Pixels outside the element bbox are transparent (no canvas corruption)