### PR TITLE
perf: O(1) ID index for `<use>`, eliminate AffineTransform allocations in transforms

### DIFF
--- a/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
+++ b/src/main/java/io/brunoborges/jairosvg/draw/Defs.java
@@ -79,6 +79,9 @@ public final class Defs {
         if (id == null)
             return;
 
+        // Build global ID index for O(1) <use> and cross-reference lookups
+        surface.nodeById.put(id, node);
+
         if (tag.contains("marker"))
             surface.markers.put(id, node);
         if (tag.contains("gradient"))
@@ -435,8 +438,8 @@ public final class Defs {
         if (fragment == null)
             return;
 
-        // Find referenced element by ID in the tree
-        Node refNode = findNodeById(surface.rootNode, fragment);
+        // Find referenced element by ID in the index (O(1) instead of O(n) tree walk)
+        Node refNode = surface.nodeById.get(fragment);
         if (refNode == null)
             return;
 

--- a/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
+++ b/src/main/java/io/brunoborges/jairosvg/surface/Surface.java
@@ -121,6 +121,9 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
     }
     public final IdentityHashMap<Node, GradientStops> gradientStopCache = new IdentityHashMap<>();
 
+    // ID index for O(1) element lookup (used by <use> and others)
+    public final Map<String, Node> nodeById = new HashMap<>();
+
     public Surface() {
     }
 
@@ -292,7 +295,6 @@ public sealed class Surface permits PngSurface, JpegSurface, TiffSurface, PdfSur
 
         this.fontSize = size(this, node.get("font-size", "12pt"));
 
-        AffineTransform savedTransform = context.getTransform();
         int savedDepth = transformDepth;
         transformStack[transformDepth++].setTransform(context.getTransform());
         Shape savedClip = context.getClip();

--- a/src/main/java/io/brunoborges/jairosvg/util/Helpers.java
+++ b/src/main/java/io/brunoborges/jairosvg/util/Helpers.java
@@ -269,6 +269,10 @@ public final class Helpers {
     }
 
     /** Parse an SVG transform string into an AffineTransform. */
+    // Reusable AffineTransform for matrix() transform function — avoids per-call
+    // allocation
+    private static final ThreadLocal<AffineTransform> TEMP_AT = ThreadLocal.withInitial(AffineTransform::new);
+
     public static AffineTransform parseTransform(Surface surface, String transformString) {
         if (transformString == null || transformString.isEmpty())
             return new AffineTransform();
@@ -289,8 +293,8 @@ public final class Helpers {
             switch (type) {
                 case "matrix" -> {
                     if (values.length >= 6) {
-                        AffineTransform m = new AffineTransform(values[0], values[1], values[2], values[3], values[4],
-                                values[5]);
+                        AffineTransform m = TEMP_AT.get();
+                        m.setTransform(values[0], values[1], values[2], values[3], values[4], values[5]);
                         matrix.concatenate(m);
                     }
                 }
@@ -302,14 +306,8 @@ public final class Helpers {
                     matrix.rotate(angle);
                     matrix.translate(-cx, -cy);
                 }
-                case "skewX" -> {
-                    double tangent = Math.tan(Math.toRadians(values[0]));
-                    matrix.concatenate(new AffineTransform(1, 0, tangent, 1, 0, 0));
-                }
-                case "skewY" -> {
-                    double tangent = Math.tan(Math.toRadians(values[0]));
-                    matrix.concatenate(new AffineTransform(1, tangent, 0, 1, 0, 0));
-                }
+                case "skewX" -> matrix.shear(Math.tan(Math.toRadians(values[0])), 0);
+                case "skewY" -> matrix.shear(0, Math.tan(Math.toRadians(values[0])));
                 case "translate" -> {
                     double tx = values[0];
                     double ty = values.length > 1 ? values[1] : 0;


### PR DESCRIPTION
Addresses issues #140 (use/defs 8.87% slower) and #142 (transforms 7.37% slower).

## Changes

### `<use>` element ID lookup — O(n) → O(1) (#140)

`Defs.use()` was calling `findNodeById(surface.rootNode, fragment)` — a full recursive DFS tree walk — for **every** `<use>` element rendered. With 7 `<use>` elements in the test SVG, that's 7 complete tree traversals per render.

Fix: added `nodeById: Map<String, Node>` to `Surface`, populated in `Defs.parseDef()` during the existing `parseAllDefs()` pass (which already walks every node). Lookup in `Defs.use()` is now a single `HashMap.get()`.

### Eliminate redundant `getTransform()` in `Surface.draw()` (#142)

`context.getTransform()` was called **twice** per node visit (lines 295 and 297). The first result (`savedTransform`) was never actually read — state is restored from `transformStack[savedDepth]`. Removed the unnecessary first call and its allocation.

### `skewX`/`skewY` transform allocations (#142)

`parseTransform` was doing:
```java
matrix.concatenate(new AffineTransform(1, 0, tangent, 1, 0, 0));  // skewX
matrix.concatenate(new AffineTransform(1, tangent, 0, 1, 0, 0));  // skewY
```
`AffineTransform.shear(shx, shy)` is exactly equivalent and allocation-free:
```java
matrix.shear(tangent, 0);  // skewX
matrix.shear(0, tangent);  // skewY
```

### `matrix()` transform allocation (#142)

The `matrix()` transform function was allocating a new `AffineTransform` per call. Replaced with a thread-local reusable instance (`TEMP_AT`) that is reset with `setTransform()` each use.